### PR TITLE
Added an iframe to host an interactive image classification example

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -218,7 +218,18 @@ const Features = props => (
   </Block>
 );
 
-
+class Iframe extends React.Component {
+  render() {
+    return(
+      <div>
+        <iframe src="https://yining1023.github.io/ml5_image_classification_dragdrop/"
+          height="500"
+          width="100%"
+        />
+      </div>
+    )
+  }
+};
 
 
 
@@ -228,10 +239,11 @@ class Index extends React.Component {
 
     return (
       <div>
-         <Why  />
-         <Code />
-         <Texts  />
-         <Examples  />
+        <Why  />
+        <Iframe />
+        <Code />
+        <Texts  />
+        <Examples  />
       </div>
     );
   }


### PR DESCRIPTION
I made a React drag and drop image classification demo here: https://codesandbox.io/s/vmnpk88y70. And when I tried to integrate it to the ml5-website, I found out that because we were using [Docusaurus](https://docusaurus.io/), we couldn't add any interactive component to the site(Here is one related GitHub [issue](https://github.com/facebook/Docusaurus/issues/584)) 😕

So I just added an iframe here, and am hosting the image classification example on my Github: https://yining1023.github.io/ml5_image_classification_dragdrop/. It works well, but we still need to make some changes to the example itself, things like resizing the image, not accepting files other than an image. I could keep working on these small changes tonight. And then we could style it a little.

Maybe we can make a repo for hosting mage_classification_dragdrop example in ml5 group @shiffman?

